### PR TITLE
Update Tensorflow in 10.ipynb

### DIFF
--- a/Tensorflow in 10.ipynb
+++ b/Tensorflow in 10.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.compile(loss='binary_crossentropy', optimizer='sgd', metrics='accuracy')"
+    "model.compile(loss='binary_crossentropy', optimizer='sgd', metrics=['accuracy'])"
    ]
   },
   {


### PR DESCRIPTION
## Fix ValueError

In my case Jupyter Notebook was throwing the following error: 

```bash
ValueError                                Traceback (most recent call last)
Cell In[16], [line 1](vscode-notebook-cell:?execution_count=16&line=1)
----> [1](vscode-notebook-cell:?execution_count=16&line=1) model.compile(loss='binary_crossentropy', optimizer='sgd', metrics='accuracy')

File /opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:122, in filter_traceback.<locals>.error_handler(*args, **kwargs)
    [119](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:119)     filtered_tb = _process_traceback_frames(e.__traceback__)
    [120](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:120)     # To get the full stack trace, call:
    [121](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:121)     # `keras.config.disable_traceback_filtering()`
--> [122](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:122)     raise e.with_traceback(filtered_tb) from None
    [123](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:123) finally:
    [124](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:124)     del filtered_tb

File /opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:130, in CompileMetrics.__init__(self, metrics, weighted_metrics, name, output_names)
    [128](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:128) super().__init__(name=name)
    [129](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:129) if metrics and not isinstance(metrics, (list, tuple, dict)):
--> [130](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:130)     raise ValueError(
    [131](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:131)         "Expected `metrics` argument to be a list, tuple, or dict. "
    [132](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:132)         f"Received instead: metrics={metrics} of type {type(metrics)}"
    [133](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:133)     )
    [134](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:134) if weighted_metrics and not isinstance(
    [135](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:135)     weighted_metrics, (list, tuple, dict)
    [136](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:136) ):
    [137](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:137)     raise ValueError(
    [138](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:138)         "Expected `weighted_metrics` argument to be a list, tuple, or "
    [139](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:139)         f"dict. Received instead: weighted_metrics={weighted_metrics} "
    [140](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:140)         f"of type {type(weighted_metrics)}"
    [141](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/trainers/compile_utils.py:141)     )

ValueError: Expected `metrics` argument to be a list, tuple, or dict. Received instead: metrics=accuracy of type <class 'str'>
```