### PR TITLE
Update Tensorflow in 10.ipynb

### DIFF
--- a/Tensorflow in 10.ipynb
+++ b/Tensorflow in 10.ipynb
@@ -552,7 +552,7 @@
     }
    ],
    "source": [
-    "model.save('tfmodel')"
+    "model.save('tfmodel.keras')"
    ]
   },
   {

--- a/Tensorflow in 10.ipynb
+++ b/Tensorflow in 10.ipynb
@@ -570,7 +570,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = load_model('tfmodel')"
+    "model = load_model('tfmodel.keras')"
    ]
   }
  ],


### PR DESCRIPTION
## Fix ValueError

While running the demo I found the following issue:

```bash
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[19], [line 1](vscode-notebook-cell:?execution_count=19&line=1)
----> [1](vscode-notebook-cell:?execution_count=19&line=1) model.save("tfmodel")

File /opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:122, in filter_traceback.<locals>.error_handler(*args, **kwargs)
    [119](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:119)     filtered_tb = _process_traceback_frames(e.__traceback__)
    [120](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:120)     # To get the full stack trace, call:
    [121](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:121)     # `keras.config.disable_traceback_filtering()`
--> [122](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:122)     raise e.with_traceback(filtered_tb) from None
    [123](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:123) finally:
    [124](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:124)     del filtered_tb

File /opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:114, in save_model(model, filepath, overwrite, zipped, **kwargs)
    [110](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:110) if str(filepath).endswith((".h5", ".hdf5")):
    [111](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:111)     return legacy_h5_format.save_model_to_hdf5(
    [112](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:112)         model, filepath, overwrite, include_optimizer
    [113](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:113)     )
--> [114](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:114) raise ValueError(
    [115](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:115)     "Invalid filepath extension for saving. "
    [116](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:116)     "Please add either a `.keras` extension for the native Keras "
    [117](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:117)     f"format (recommended) or a `.h5` extension. "
    [118](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:118)     "Use `model.export(filepath)` if you want to export a SavedModel "
    [119](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:119)     "for use with TFLite/TFServing/etc. "
    [120](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:120)     f"Received: filepath={filepath}."
    [121](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/anaconda3/lib/python3.12/site-packages/keras/src/saving/saving_api.py:121) )

ValueError: Invalid filepath extension for saving. Please add either a `.keras` extension for the native Keras format (recommended) or a `.h5` extension. Use `model.export(filepath)` if you want to export a SavedModel for use with TFLite/TFServing/etc. Received: filepath=tfmodel.
```